### PR TITLE
Remove --compilers flag from mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register",
+    "test": "mocha",
     "lint": "eslint .",
     "build": "browserify -r -t [ babelify --presets [ es2015 ] ] index.js -o bundle.js"
   },


### PR DESCRIPTION
Information online seems to indicate that this flag is deprecated;
trying to just remove it, see if things work.